### PR TITLE
Prevent eager matching of tld

### DIFF
--- a/src/RdapDns.php
+++ b/src/RdapDns.php
@@ -25,7 +25,7 @@ class RdapDns
                 $tlds = $tldServerProperties[0];
 
                 foreach ($tlds as $tld) {
-                    if (str_ends_with($domain, $tld)) {
+                    if (str_ends_with($domain, ".{$tld}")) {
                         return true;
                     }
                 }


### PR DESCRIPTION
This pull request addresses an issue where we match the wrong tld by being too eager when searching for text ending with a specific suffix. For example, when searching for the domain 'paya.mobi' we incorrectly match 'obi' instead, leading to incorrect results.