### PR TITLE
Handle invalid RDAP response

### DIFF
--- a/README.md
+++ b/README.md
@@ -165,9 +165,13 @@ $domain = Rdap::domain('google.com'); // returns an instance of `Spatie\Rdap\Res
 
 If you pass a non-existing domain, then the `domain()` function will return `null`.
 
-## Handling timeouts
+## Handling errors
 
 Sometimes RDAP is slow in responding. If a response isn't returned in a timely manner, a `Spatie\Rdap\Exceptions\RdapRequestTimedOut` exception will be thrown.
+
+Sometimes RDAP servers return with an invalid response. If that happens, a `Spatie\Rdap\Exceptions\InvalidRdapResponse` exception will be thrown.
+
+Both exceptions implement `Spatie\Rdap\Exceptions\RdapException`. You can catch that exception to handle both cases.
 
 ## Working with RDAP DNS
 

--- a/src/Exceptions/InvalidRdapResponse.php
+++ b/src/Exceptions/InvalidRdapResponse.php
@@ -1,0 +1,16 @@
+<?php
+
+namespace Spatie\Rdap\Exceptions;
+
+use Exception;
+use Illuminate\Http\Client\ConnectionException;
+
+class InvalidRdapResponse extends Exception implements RdapException
+{
+    public static function make(string $domain): self
+    {
+        return new static(
+            "The request to RDAP to get domain data for `{$domain}` returned a invalid response.",
+        );
+    }
+}

--- a/src/Exceptions/RdapException.php
+++ b/src/Exceptions/RdapException.php
@@ -1,0 +1,8 @@
+<?php
+
+namespace Spatie\Rdap\Exceptions;
+
+interface RdapException
+{
+
+}

--- a/src/Exceptions/RdapRequestTimedOut.php
+++ b/src/Exceptions/RdapRequestTimedOut.php
@@ -5,9 +5,9 @@ namespace Spatie\Rdap\Exceptions;
 use Exception;
 use Illuminate\Http\Client\ConnectionException;
 
-class RdapRequestTimedOut extends Exception
+class RdapRequestTimedOut extends Exception implements RdapException
 {
-    public static function make(string $domain, ConnectionException $exception)
+    public static function make(string $domain, ConnectionException $exception): self
     {
         return new static(
             "The request to RDAP to get domain data for `{$domain}` timed out.",

--- a/src/Rdap.php
+++ b/src/Rdap.php
@@ -5,6 +5,7 @@ namespace Spatie\Rdap;
 use Illuminate\Http\Client\ConnectionException;
 use Illuminate\Http\Client\RequestException;
 use Illuminate\Support\Facades\Http;
+use Spatie\Rdap\Exceptions\InvalidRdapResponse;
 use Spatie\Rdap\Exceptions\RdapRequestTimedOut;
 use Spatie\Rdap\Responses\DomainResponse;
 
@@ -45,6 +46,12 @@ class Rdap
             throw $exception;
         } catch (ConnectionException $exception) {
             throw RdapRequestTimedOut::make($domain, $exception);
+        }
+
+        if (empty($response)) {
+            // Some misconfigured RDAP servers might return (invalid) HTML responses.
+            // The JSON conversion will return an empty array in that case.
+            throw InvalidRdapResponse::make($domain);
         }
 
         return new DomainResponse($response);

--- a/tests/RdapTest.php
+++ b/tests/RdapTest.php
@@ -1,6 +1,8 @@
 <?php
 
+use Illuminate\Support\Facades\Http;
 use Spatie\Rdap\CouldNotFindRdapServer;
+use Spatie\Rdap\Exceptions\InvalidRdapResponse;
 use Spatie\Rdap\Exceptions\RdapRequestTimedOut;
 use Spatie\Rdap\Rdap;
 use Spatie\Rdap\Responses\DomainResponse;
@@ -50,5 +52,20 @@ it('could throw a time out exception if getting results takes too long', functio
         //sometimes it times out
     } catch (RdapRequestTimedOut $timedOut) {
         expect($timedOut)->toBeInstanceOf(RdapRequestTimedOut::class);
+    }
+});
+
+it('throws a invalid response exception if rdap servers returns invalid response', function () {
+    Http::fake([
+        'rdap.nic.io/*' => Http::response('invalid response'),
+    ]);
+
+    try {
+        $result = $this->rdap->domain('invalid-domain-response.com');
+
+        // sometimes it returns null
+        expect($result)->toBeNull();
+    } catch (InvalidRdapResponse $invalidResponse) {
+        expect($invalidResponse)->toBeInstanceOf(InvalidRdapResponse::class);
     }
 });


### PR DESCRIPTION
Some RDAP servers return an invalid response, i.e. for instance the `.cloud` RDAP server currently returns an HTML response.

This PR adds an `InvalidRdapResponse` exception, as well as a generic `RdapException` interface.

```
curl https://rdap.nic.cloud/domain/test.cloud
<a href="/">Found</a>.
```