### PR TITLE
Fix: PHP 8.4 deprecation

### DIFF
--- a/src/Rdap.php
+++ b/src/Rdap.php
@@ -17,9 +17,9 @@ class Rdap
 
     public function domain(
         string $domain,
-        int $timeoutInSeconds = null,
-        int $retryTimes = null,
-        int $sleepInMillisecondsBetweenRetries = null,
+        ?int $timeoutInSeconds = null,
+        ?int $retryTimes = null,
+        ?int $sleepInMillisecondsBetweenRetries = null,
     ): ?DomainResponse {
         $dnsServer = $this->rdapDns->getServerForDomain($domain);
 


### PR DESCRIPTION
Added explicit nullable on Domain class constructor on nullable properties.